### PR TITLE
Fix bug found during tax-residency issuance

### DIFF
--- a/app/dynamic_func.py
+++ b/app/dynamic_func.py
@@ -158,10 +158,7 @@ def formatter(data, un_distinguishing_sign, scope, format):
     )
 
     # Normalize list and type fields
-    normalize_list_and_type_fields(data, attributes_req, attributes_req2)
-
-    if requested_credential.get("scope") == "eu.europa.ec.eudi.pid_vc_sd_jwt":
-        normalize_address(data, attributes_req, attributes_req2)
+    normalize_list_and_type_fields(data, attributes_req, attributes_req2, requested_credential.get("scope"))
 
     # Populate pdata
     populate_pdata(
@@ -251,7 +248,7 @@ def update_dates_and_special_claims(
         data["credential_type"] = doctype_config["credential_type"]
 
 
-def normalize_list_and_type_fields(data, attributes_req, attributes_req2):
+def normalize_list_and_type_fields(data, attributes_req, attributes_req2, scope=None):
     list_fields = [
         "places_of_work",
         "legislation",
@@ -261,6 +258,9 @@ def normalize_list_and_type_fields(data, attributes_req, attributes_req2):
         "subject",
         "residence_address"
     ]
+
+    if scope == "eu.europa.ec.eudi.pid_vc_sd_jwt":
+        list_fields.append("address")
 
     for field in list_fields:
         if field in attributes_req and field in data:
@@ -286,24 +286,6 @@ def normalize_list_and_type_fields(data, attributes_req, attributes_req2):
         and data["gender"].isdigit()
     ):
         data["gender"] = int(data["gender"])
-
-def normalize_address(data, attributes_req, attributes_req2):
-    list_fields = [
-        "address"
-    ]
-
-    for field in list_fields:
-        if field in attributes_req and field in data:
-            if isinstance(data[field], str):
-                data[field] = json.loads(data[field])
-            if isinstance(data[field], list):
-                data[field] = data[field][0]
-
-        if field in attributes_req2 and field in data:
-            if isinstance(data[field], str):
-                data[field] = json.loads(data[field])
-            if isinstance(data[field], list):
-                data[field] = data[field][0]
 
 def populate_pdata(
     data,

--- a/app/dynamic_func.py
+++ b/app/dynamic_func.py
@@ -160,6 +160,9 @@ def formatter(data, un_distinguishing_sign, scope, format):
     # Normalize list and type fields
     normalize_list_and_type_fields(data, attributes_req, attributes_req2)
 
+    if requested_credential.get("scope") == "eu.europa.ec.eudi.pid_vc_sd_jwt":
+        normalize_address(data, attributes_req, attributes_req2)
+
     # Populate pdata
     populate_pdata(
         data,
@@ -256,8 +259,7 @@ def normalize_list_and_type_fields(data, attributes_req, attributes_req2):
         "competent_institution",
         "credential_holder",
         "subject",
-        "residence_address",
-        "address"
+        "residence_address"
     ]
 
     for field in list_fields:
@@ -285,6 +287,23 @@ def normalize_list_and_type_fields(data, attributes_req, attributes_req2):
     ):
         data["gender"] = int(data["gender"])
 
+def normalize_address(data, attributes_req, attributes_req2):
+    list_fields = [
+        "address"
+    ]
+
+    for field in list_fields:
+        if field in attributes_req and field in data:
+            if isinstance(data[field], str):
+                data[field] = json.loads(data[field])
+            if isinstance(data[field], list):
+                data[field] = data[field][0]
+
+        if field in attributes_req2 and field in data:
+            if isinstance(data[field], str):
+                data[field] = json.loads(data[field])
+            if isinstance(data[field], list):
+                data[field] = data[field][0]
 
 def populate_pdata(
     data,


### PR DESCRIPTION
The function `normalize_list_and_type_fields` called by the function `formatter` was normalizing the `address` claim for all issuance flows. This is needed for PID SD-JWT, where `address` is received as a list and needs to be converted into a JSON object, but it was also unintentionally affecting tax-residency issuance. The function has been updated to scope the address normalization to PID SD-JWT only, leaving `address` untouched in other flows.